### PR TITLE
chore(ci): don't run CodeQL on pr

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,8 +3,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   schedule:
     - cron: '35 6 * * 1'
 


### PR DESCRIPTION
It takes too long to wait for on every PR. I want PR checks to happen very fast.

This will still run on merge into main.